### PR TITLE
39-Contact info visibility

### DIFF
--- a/goco-transit/src/pages/settings-page.js
+++ b/goco-transit/src/pages/settings-page.js
@@ -34,8 +34,9 @@ class SettingsPage extends React.Component {
       phoneNum: null,
       email: null,
     }
-    // The click handler needs "this"
+    // The click handlers needs "this"
     this.handleClickLogout = this.handleClickLogout.bind(this);
+    this.handleClickEdit = this.handleClickEdit.bind(this);
   }
 
   componentWillMount() {
@@ -47,12 +48,14 @@ class SettingsPage extends React.Component {
    */
   async loadUserData() {
     let data = await getUser();
+    console.log(data);
     this.setState({
       user: data,
       firstName: data.firstName,
       lastName: data.lastName,
       phoneNum: data.phoneNum,
       email: data.email,
+      userName: data.userName
     });
   };
 
@@ -60,6 +63,11 @@ class SettingsPage extends React.Component {
   handleClickLogout() {
     signOut();
     this.setState({ triggerReRender: true });
+  }
+
+  // Redirect to 360 to edit user info
+  handleClickEdit() {
+    window.location = "https://360.gordon.edu/#/profile/" + this.state.userName;
   }
 
   // Bind dialog data to the state
@@ -88,7 +96,7 @@ class SettingsPage extends React.Component {
             <Grid item xs={4}>
               <Grid container direction="row" justify="flex-end" alignItems="center">
                 <Grid item>
-                  <Button variant="fab" color="secondary" aria-label="add">
+                  <Button variant="fab" color="secondary" aria-label="add" onClick={this.handleClickEdit}>
                     {Icons.editIcon}
                   </Button>
                 </Grid>
@@ -106,38 +114,6 @@ class SettingsPage extends React.Component {
             Email: {this.state.email}
           </div>
 
-          {/* Decide which contact information will be shared with riders */}
-          <h3>
-            Contact Information to Share
-          </h3>
-
-          <FormGroup row>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={this.state.displayPhone}
-                  onChange={this.handleChange('displayPhone')}
-                  value="displayPhone"
-                  color="secondary"
-                />
-              }
-              label="Phone Number"
-            />
-          </FormGroup>
-
-          <FormGroup row>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={this.state.displayEmail}
-                  onChange={this.handleChange('displayEmail')}
-                  value="displayEmail"
-                />
-              }
-              label="Email Address"
-            />
-          </FormGroup>
-
           {/* Shows which legal agreements have been completed */}
           <h3>
             Legal Agreements
@@ -147,8 +123,8 @@ class SettingsPage extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={this.state.waiverComplete}
-                  onChange={this.handleChange('waiverComplete')}
                   value="waiverComplete"
                 />
               }
@@ -160,8 +136,8 @@ class SettingsPage extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={this.state.privacyComplete}
-                  onChange={this.handleChange('privacyComplete')}
                   value="privacyComplete"
                 />
               }
@@ -173,8 +149,8 @@ class SettingsPage extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
+                  color="primary"
                   checked={this.state.termsComplete}
-                  onChange={this.handleChange('termsComplete')}
                   value="termsComplete"
                 />
               }


### PR DESCRIPTION
Getting rid of the section that allows you to change contact info visibility. Legal documentation check boxes can't be manually changed and are the proper color to reflect non-interaction. The edit button on the contact info section now redirects to your 360 profile page.