### PR TITLE
99-Tab not changing with browser buttons

### DIFF
--- a/goco-transit/src/pages/driver-page.js
+++ b/goco-transit/src/pages/driver-page.js
@@ -8,6 +8,7 @@ import IconButton from 'material-ui/IconButton';
 import Button from 'material-ui/Button';
 import Grid from 'material-ui/Grid';
 import Badge from 'material-ui/Badge';
+import PropTypes from 'prop-types';
 
 // Components
 import OfferDetailsDialog from '../components/dialog-boxes/offer-details-dialog';
@@ -20,8 +21,8 @@ import { getUser } from '../services/user-service';
 
 // Contains rides offered to other users
 class DriverPage extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       dense: false,
@@ -35,6 +36,8 @@ class DriverPage extends React.Component {
   }
 
   componentWillMount() {
+    // Once the component mounts, make sure the tab matches the component
+    this.props.matchTab();
     this.loadUserData();
   }
 
@@ -118,5 +121,9 @@ class DriverPage extends React.Component {
   };
 
 }
+
+DriverPage.propTypes = {
+  matchTab: PropTypes.func.isRequired,
+};
 
 export default DriverPage;

--- a/goco-transit/src/pages/main-page.js
+++ b/goco-transit/src/pages/main-page.js
@@ -2,7 +2,7 @@ import React from 'react';
 import AppBar from 'material-ui/AppBar';
 import Tabs, { Tab } from 'material-ui/Tabs';
 import Typography from 'material-ui/Typography';
-import { Link, Route } from 'react-router-dom';
+import { Link, Route, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 // Components
@@ -39,6 +39,23 @@ class MainPage extends React.Component {
   handleChange = (event, value) => {
     this.setState({ value });
   };
+
+  componentWillMount() {
+    // Will change the tab when browser forward and back buttons are used
+    // to switch between components rather than the user clicking on the tabs
+    this.props.history.listen(() => {
+      let path = this.props.history.location.pathname;
+      if (path === '/' || path.includes('/passenger')) {
+        this.setState({ value: 0 });
+      }
+      else if (path.includes('/driver')) {
+        this.setState({ value: 1 });
+      }
+      else if (path.includes('/settings')) {
+        this.setState({ value: 2 });
+      }
+    });
+  }
 
   render() {
     return (
@@ -91,4 +108,4 @@ MainPage.propTypes = {
   onLogout: PropTypes.func.isRequired,
 };
 
-export default MainPage;
+export default withRouter(MainPage);

--- a/goco-transit/src/pages/main-page.js
+++ b/goco-transit/src/pages/main-page.js
@@ -33,30 +33,7 @@ class MainPage extends React.Component {
       value: 0,
     };
 
-    this.matchTabToRoute = this.matchTabToRoute.bind(this);
-
     this.loadUserData();
-  }
-
-  handleChange = (event, value) => {
-    this.setState({ value });
-  };
-
-  /**
-   * Whenever the route is changed or set without using the tab buttons
-   * this method can be used to match the tab to the current route
-   */
-  matchTabToRoute() {
-    let path = this.props.history.location.pathname;
-    if (path === '/' || path.includes('/passenger')) {
-      this.setState({ value: 0 });
-    }
-    else if (path.includes('/driver')) {
-      this.setState({ value: 1 });
-    }
-    else if (path.includes('/settings')) {
-      this.setState({ value: 2 });
-    }
   }
 
   render() {
@@ -68,7 +45,6 @@ class MainPage extends React.Component {
             <Tabs
               fullWidth={true}
               value={this.state.value}
-              onChange={this.handleChange}
               indicatorColor="secondary"
               centered
             >
@@ -85,28 +61,28 @@ class MainPage extends React.Component {
             <Route
               exact path="/"
               render={() => <PassengerPage
-                matchTab={this.matchTabToRoute}>
+                matchTab={() => this.setState({ value: 0 })}>
               </PassengerPage>} />
             <Route
               exact path="/passenger"
               render={() => <PassengerPage
-                matchTab={this.matchTabToRoute}>
+                matchTab={() => this.setState({ value: 0 })}>
               </PassengerPage>} />
             <Route
               exact path="/passenger/search"
               render={() => <SearchPage
-                matchTab={this.matchTabToRoute}>
+                matchTab={() => this.setState({ value: 0 })}>
               </SearchPage>} />
             <Route
               exact path="/driver"
               render={() => <DriverPage
-                matchTab={this.matchTabToRoute}>
+                matchTab={() => this.setState({ value: 1 })}>
               </DriverPage>} />
             <Route
               exact path="/settings"
               render={() => <SettingsPage
                 onLogout={this.props.onLogout}
-                matchTab={this.matchTabToRoute}>
+                matchTab={() => this.setState({ value: 2 })}>
               </SettingsPage>} />
           </TabContainer>
         </div>

--- a/goco-transit/src/pages/main-page.js
+++ b/goco-transit/src/pages/main-page.js
@@ -33,6 +33,8 @@ class MainPage extends React.Component {
       value: 0,
     };
 
+    this.matchTabToRoute = this.matchTabToRoute.bind(this);
+
     this.loadUserData();
   }
 
@@ -40,21 +42,21 @@ class MainPage extends React.Component {
     this.setState({ value });
   };
 
-  componentWillMount() {
-    // Will change the tab when browser forward and back buttons are used
-    // to switch between components rather than the user clicking on the tabs
-    this.props.history.listen(() => {
-      let path = this.props.history.location.pathname;
-      if (path === '/' || path.includes('/passenger')) {
-        this.setState({ value: 0 });
-      }
-      else if (path.includes('/driver')) {
-        this.setState({ value: 1 });
-      }
-      else if (path.includes('/settings')) {
-        this.setState({ value: 2 });
-      }
-    });
+  /**
+   * Whenever the route is changed or set without using the tab buttons
+   * this method can be used to match the tab to the current route
+   */
+  matchTabToRoute() {
+    let path = this.props.history.location.pathname;
+    if (path === '/' || path.includes('/passenger')) {
+      this.setState({ value: 0 });
+    }
+    else if (path.includes('/driver')) {
+      this.setState({ value: 1 });
+    }
+    else if (path.includes('/settings')) {
+      this.setState({ value: 2 });
+    }
   }
 
   render() {
@@ -80,15 +82,32 @@ class MainPage extends React.Component {
         {/* Tab Pages */}
         <div style={{ paddingTop: '4.25em' }}>
           <TabContainer>
-            <Route exact path="/" component={PassengerPage} />
-            <Route exact path="/passenger" component={PassengerPage} />
-            <Route exact path="/passenger/search" component={SearchPage} />
-            <Route exact path="/driver" component={DriverPage} />
-            {/* This route is different because we need to get the logout property from it
-             and pass that message to the app component */}
+            <Route
+              exact path="/"
+              render={() => <PassengerPage
+                matchTab={this.matchTabToRoute}>
+              </PassengerPage>} />
+            <Route
+              exact path="/passenger"
+              render={() => <PassengerPage
+                matchTab={this.matchTabToRoute}>
+              </PassengerPage>} />
+            <Route
+              exact path="/passenger/search"
+              render={() => <SearchPage
+                matchTab={this.matchTabToRoute}>
+              </SearchPage>} />
+            <Route
+              exact path="/driver"
+              render={() => <DriverPage
+                matchTab={this.matchTabToRoute}>
+              </DriverPage>} />
             <Route
               exact path="/settings"
-              render={() => <SettingsPage onLogout={this.props.onLogout}></SettingsPage>} />
+              render={() => <SettingsPage
+                onLogout={this.props.onLogout}
+                matchTab={this.matchTabToRoute}>
+              </SettingsPage>} />
           </TabContainer>
         </div>
       </div>

--- a/goco-transit/src/pages/passenger-page.js
+++ b/goco-transit/src/pages/passenger-page.js
@@ -6,6 +6,7 @@ import List, {
 import Button from 'material-ui/Button';
 import Grid from 'material-ui/Grid';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 // Components
 import RequestedDetailsDialog from '../components/dialog-boxes/requested-details-dialog';
@@ -18,8 +19,8 @@ import { getUser } from '../services/user-service';
 
 // Contains ride requests made by the user
 class PassengerPage extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       dense: false,
@@ -34,6 +35,8 @@ class PassengerPage extends React.Component {
   }
 
   componentWillMount() {
+    // Once the component mounts, make sure the tab matches the component
+    this.props.matchTab();
     this.loadUserData();
   }
 
@@ -138,5 +141,9 @@ class PassengerPage extends React.Component {
   };
 
 }
+
+PassengerPage.propTypes = {
+  matchTab: PropTypes.func.isRequired,
+};
 
 export default PassengerPage;

--- a/goco-transit/src/pages/search-page.js
+++ b/goco-transit/src/pages/search-page.js
@@ -6,6 +6,7 @@ import List, {
   ListItemText,
 } from 'material-ui/List'; import Avatar from 'material-ui/Avatar';
 import Button from 'material-ui/Button';
+import PropTypes from 'prop-types';
 
 // Components
 import AddRequestDialog from '../components/dialog-boxes/add-request-dialog';
@@ -17,9 +18,9 @@ import { findOfferedRides } from '../services/ride-service';
  * This page is displayed when a user wants to find a ride somewhere.
  * It allows the user to search for a ride by location and date range
  */
-class RequestSearchPage extends React.Component {
-  constructor() {
-    super();
+class SearchPage extends React.Component {
+  constructor(props) {
+    super(props);
 
     this.state = {
       dense: false,
@@ -33,6 +34,11 @@ class RequestSearchPage extends React.Component {
       endDate: null,
       results: null
     };
+  }
+
+  componentWillMount() {
+    // Once the component mounts, make sure the tab matches the component
+    this.props.matchTab();
   }
 
   // Returns the date and time plus a given number of milliseconds (ms) in datetime-local format ("YYYY-MM-DDTHH:MM")
@@ -190,4 +196,8 @@ class RequestSearchPage extends React.Component {
   }
 }
 
-export default RequestSearchPage;
+SearchPage.propTypes = {
+  matchTab: PropTypes.func.isRequired,
+};
+
+export default SearchPage;

--- a/goco-transit/src/pages/settings-page.js
+++ b/goco-transit/src/pages/settings-page.js
@@ -42,6 +42,8 @@ class SettingsPage extends React.Component {
   }
 
   componentWillMount() {
+    // Once the component mounts, make sure the tab matches the component
+    this.props.matchTab();
     this.loadUserData();
   }
 
@@ -197,6 +199,7 @@ class SettingsPage extends React.Component {
 
 SettingsPage.propTypes = {
   onLogout: PropTypes.func.isRequired,
+  matchTab: PropTypes.func.isRequired,
 };
 
 export default SettingsPage;

--- a/goco-transit/src/pages/settings-page.js
+++ b/goco-transit/src/pages/settings-page.js
@@ -4,6 +4,7 @@ import Button from 'material-ui/Button';
 import { FormGroup, FormControlLabel } from 'material-ui/Form';
 import Checkbox from 'material-ui/Checkbox';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 // Components
 import { Icons } from '../icon-library';
@@ -151,15 +152,18 @@ class SettingsPage extends React.Component {
           <div style={{ padding: '.75em', }}>
           </div>
 
-          {/* Button to logout */}
-          <Button
-            variant="raised"
-            color="secondary"
-            style={{ width: '100%', }}
-            onClick={this.handleClickLogout}
-          >
-            Logout
+          {/* Button to logout
+           the link keeps the url from remaining at the "settings" page after logout */}
+          <Link to="/" style={{ textDecoration: 'none' }}>
+            <Button
+              variant="raised"
+              color="secondary"
+              style={{ width: '100%', }}
+              onClick={this.handleClickLogout}
+            >
+              Logout
             </Button>
+          </Link>
         </div>
       );
     }


### PR DESCRIPTION
This fixes all known issues with routing

- tabs now change when you change the url
- /settings doesn't stay in the url after logout
- using browser forward and back buttons changes the tab
- when a page is set in the url before login, that page and its tab will be loaded after login

How this is accomplished

- the "MainPage" no longer sets the tab except when it is first constructed
- instead, the children change the tab once they have been mounted
- the settings page logout button is wrapped in a link which changes the route before it logs out